### PR TITLE
fix: allow proceeding even when offline check fails/wrong

### DIFF
--- a/src/components/PreparationStep.js
+++ b/src/components/PreparationStep.js
@@ -25,7 +25,9 @@ const PreparationStep = ({ isOnline, onContinue }) => {
             return; // Can't uncheck offline when actually offline
         }
         
+        // Checking offline while online counts as accepting the risk
         if (item === 'offline' && isOnline && !proceedOnline) {
+            handleProceedOnline();
             return;
         }
         

--- a/src/components/SecurityPreparationStep.jsx
+++ b/src/components/SecurityPreparationStep.jsx
@@ -24,8 +24,9 @@ const SecurityPreparationStep = ({ isOnline, onContinue, onBack }) => {
             return; // Can't uncheck offline when actually offline
         }
         
-        // Allow checking offline if user chose to proceed online
+        // Checking offline while online counts as accepting the risk
         if (item === 'offline' && isOnline && !proceedOnline) {
+            handleProceedOnline();
             return;
         }
         

--- a/src/style/createPage.css
+++ b/src/style/createPage.css
@@ -2802,7 +2802,6 @@
 
 .checklist-item.disabled {
     opacity: 0.6;
-    cursor: not-allowed;
 }
 
 .checklist-content {

--- a/src/style/unlockPage.css
+++ b/src/style/unlockPage.css
@@ -1053,7 +1053,6 @@
 
 .checklist-item.disabled {
     opacity: 0.6;
-    cursor: not-allowed;
     background: rgba(244, 67, 54, 0.05);
     border: 1px solid rgba(244, 67, 54, 0.2);
 }


### PR DESCRIPTION
Just a small thing, but as mentioned the offline check is sometime wrong, especially on Firefox (it's hard to accuratley detect). So this let's the user still proceed even when online (with warning still in place).

<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/f94256cb-fa58-43a8-b379-644825a86a86

</details>


<details>
<summary>After</summary>


https://github.com/user-attachments/assets/d0023101-7651-4db3-bdaa-8c8c3ac4b9f9


</details>